### PR TITLE
separate Rakefile for Jenkins

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -1,8 +1,6 @@
 require 'rubygems'
 require 'bundler'
-require 'simplecov' # for Ruby 1.9
 require 'rake/testtask'
-require 'ci/reporter/rake/test_unit'
 
 Bundler::GemHelper.install_tasks
 
@@ -12,11 +10,6 @@ task :test do |test|
     t.test_files = FileList['test/**/*.rb']
     t.verbose = true
   end
-end
-
-# for Ruby 1.8
-task :coverage do |coverage|
-  system("rcov -o test/coverage -I lib:test  --exclude . --include-file lib/jubatus --aggregate coverage.info test/**/*.rb")
 end
 
 task :default => [:build]

--- a/Rakefile.ci
+++ b/Rakefile.ci
@@ -1,0 +1,4 @@
+require 'ci/reporter/rake/test_unit'
+require 'simplecov'
+
+load 'Rakefile'


### PR DESCRIPTION
Separate Rakefile for Jenkins (Rakefile.ci) so that general users do not need special modules for continuous integration (simplecov and ci/reporter/rake/test_unit) to run tests.
