### PR TITLE
Fixed typo in namespace

### DIFF
--- a/lib/jubatus/common/client.rb
+++ b/lib/jubatus/common/client.rb
@@ -36,7 +36,7 @@ class Client
     elsif error == 2
       raise TypeMismatch
     else
-      raise MessagePack.RPC.RPCError.create(error, result)
+      raise MessagePack::RPC::RPCError.create(error, result)
     end
   end
 end


### PR DESCRIPTION
I found typo in `common/client.rb`
