### PR TITLE
remove unnecessary capitalization

### DIFF
--- a/generate.sh
+++ b/generate.sh
@@ -14,10 +14,6 @@ popd
 
 # Ruby
 
-capitalize() {
-  echo "$(echo ${1:0:1} | tr 'a-z' 'A-Z')${1:1}"
-}
-
 for DIR in "${CLIENT_DIR}/lib/jubatus/"*; do
   if [ -d "${DIR}" ] && [ "$(basename "${DIR}")" != "common" ]; then
     rm -rf $DIR
@@ -27,7 +23,7 @@ pushd "${JUBATUS_DIR}/jubatus/server/server"
 for IDL in *.idl; do
   IDL_HASH=`git log -1 --format=%H -- ${IDL}`
   IDL_VER=`git describe ${IDL_HASH}`
-  NAMESPACE="$(capitalize $(basename "${IDL}" ".idl"))"
+  NAMESPACE="$(basename "${IDL}" ".idl")"
   jenerator -l ruby "${IDL}" -n "Jubatus::${NAMESPACE}" -o "${CLIENT_DIR}/lib/jubatus" --idl-version $IDL_VER
 done
 popd


### PR DESCRIPTION
`jenerator` automatically capitalize the service name so we don't have to do this.