### PR TITLE
Add tests for set_label, get_labels and delete_label

### DIFF
--- a/integration_test/jubatus_test/classifier/test.rb
+++ b/integration_test/jubatus_test/classifier/test.rb
@@ -60,6 +60,20 @@ class ClassifierTest < Test::Unit::TestCase
     result = @cli.classify(data)
   end
 
+  def test_set_label
+    assert_equal(@cli.set_label("label"), true)
+  end
+
+  def test_get_label
+    @cli.set_label("label")
+    assert_equal(@cli.get_labels(), {"label" => 0})
+  end
+
+  def test_delete_label
+    @cli.set_label("label")
+    assert_equal(@cli.delete_label("label"), true)
+  end
+
   def test_save
     assert_equal(@cli.save("classifier.save_test.model").size, 1)
   end


### PR DESCRIPTION
This patch is a part of https://github.com/jubatus/jubatus_core/pull/272

Currently, ``set_label``, ``get_labels``, ``delete_label`` are not tested in integration_test.
I added tests about the above RPC and modified it to follow the new ``get_labels`` RPC signature.