### PR TITLE
Fix gem dependencies

### DIFF
--- a/jubatus.gemspec
+++ b/jubatus.gemspec
@@ -20,8 +20,9 @@ Gem::Specification.new do |gem|
   gem.executables = gem.files.grep(%r{^bin/}).map { |f| File.basename(f) }
   gem.require_paths = ['lib']
 
-  gem.add_dependency "msgpack-rpc", "~> 0.5.1"
+  gem.add_dependency "msgpack-rpc", ">= 0.5.1"
   gem.add_development_dependency "rake", ">= 0.9.2"
   gem.add_development_dependency "simplecov"
   gem.add_development_dependency "ci_reporter"
+  gem.add_development_dependency "test-unit", "> 3"
 end


### PR DESCRIPTION
This is for Ruby 2.4 or later.
msgpack-rpc 0.5.x depends on msgpack 0.5.x, msgpack 0.5.x uses
`rb_cFixnum`. This will cause error with Ruby 2.4 or later.

See https://bugs.ruby-lang.org/issues/12005