### PR TITLE
add ci_reporter_test_unit

### DIFF
--- a/jubatus.gemspec
+++ b/jubatus.gemspec
@@ -24,5 +24,6 @@ Gem::Specification.new do |gem|
   gem.add_development_dependency "rake", ">= 0.9.2"
   gem.add_development_dependency "simplecov"
   gem.add_development_dependency "ci_reporter"
+  gem.add_development_dependency "ci_reporter_test_unit"
   gem.add_development_dependency "test-unit", "> 3"
 end


### PR DESCRIPTION
travis failed because of the missing of `ci_reporter_test_unit`
This PR fixes the problem https://travis-ci.org/jubatus/jubatus-ruby-client/builds/294732421